### PR TITLE
Fix: The project contains header files, causing clangd to fail to load

### DIFF
--- a/uvconvertor.cpp
+++ b/uvconvertor.cpp
@@ -318,7 +318,8 @@ void uVConvertor::toCompileJson(std::string outPath,std::string extOptions)
 		}
 		m_argumentsList.pop_front();
 
-		j.push_back(j1);
+		if (j1.contains("arguments"))
+			j.push_back(j1);
     }
 	
 	


### PR DESCRIPTION
Fix: When a header file is added to the project, the header file item appears in compile_commands.json without the arguments parameter.